### PR TITLE
Modified the pro file so that we can adjust the runtime version

### DIFF
--- a/src/ACLEDExplorer/ACLEDExplorer.pro
+++ b/src/ACLEDExplorer/ACLEDExplorer.pro
@@ -27,7 +27,8 @@ equals(QT_MAJOR_VERSION, 5) {
 	}
 }
 
-ARCGIS_RUNTIME_VERSION = 100.4
+# On Windows you can use $$() but not $${} like in the arcgis*.pri project file
+ARCGIS_RUNTIME_VERSION = $$(ARCGIS_RUNTIME_VERSION)
 include($$PWD/arcgisruntime.pri)
 
 HEADERS += \

--- a/src/ACLEDExplorer/AcledLayerSource.cpp
+++ b/src/ACLEDExplorer/AcledLayerSource.cpp
@@ -32,7 +32,7 @@
 
 using namespace Esri::ArcGISRuntime;
 
-static const bool useManualCaching = true;
+static const bool useManualCaching = false;
 
 AcledLayerSource::AcledLayerSource(QObject *parent) : QObject(parent)
 {


### PR DESCRIPTION
Modified the pro file so that we can adjust the runtime version using an environment var. Populate from service behaves different using 100.11 on Windows, no features are returned by this query?